### PR TITLE
Bits or curve can be set for ssh key

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -11,6 +11,8 @@
 | private_key_extension | Private key extension | string | `` | no |
 | public_key_extension | Public key extension | string | `.pub` | no |
 | ssh_key_algorithm | SSH key algorithm | string | `RSA` | no |
+| ssh_key_bits | SSH RSA key bits | string | `2048` | no |
+| ssh_key_curve | SSH ECDSA elliptic curve | string | `P256` | no |
 | ssh_public_key_path | Path to SSH public key directory (e.g. `/secrets`) | string | - | yes |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |

--- a/main.tf
+++ b/main.tf
@@ -14,14 +14,12 @@ locals {
 }
 
 resource "tls_private_key" "default_rsa" {
-  count = "${var.ssh_key_algorithm == "RSA" ? 1 : 0}"
   algorithm = "${var.ssh_key_algorithm}"
   rsa_bits = "${var.ssh_key_bits}"
 }
 
 resource "tls_private_key" "default_ecdsa" {
   algorithm = "${var.ssh_key_algorithm}"
-  count = "${var.ssh_key_algorithm == "ECDSA" ? 1 : 0}"
   ecdsa_curve = "${var.ssh_key_curve}"
 }
 

--- a/output.tf
+++ b/output.tf
@@ -4,6 +4,6 @@ output "key_name" {
 }
 
 output "public_key" {
-  value       = "${join("", tls_private_key.default.*.public_key_openssh)}"
+  value       = "${var.ssh_key_algorithm == "RSA" ? join("", tls_private_key.default_rsa.*.public_key_openssh) : join("", tls_private_key.default_ecdsa.*.public_key_openssh)}"
   description = "Contents of the generated public key"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,18 @@ variable "ssh_key_algorithm" {
   description = "SSH key algorithm"
 }
 
+variable "ssh_key_bits" {
+  type = "string"
+  default = "2048"
+  description = "SSH RSA key bits"
+}
+
+variable "ssh_key_curve" {
+  type = "string"
+  default = "P256"
+  description = "SSH ECDSA elliptic curve"
+}
+
 variable "private_key_extension" {
   type        = "string"
   default     = ""


### PR DESCRIPTION
This creates two SSH keys in fact, but chooses what to create based on a chosen algorithm.
Cannot be created as one resource due to conflicting tls_private_key setup options.