### PR TITLE
Terraform 0.14 upgrade

### DIFF
--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -34,7 +34,7 @@ jobs:
         fi
 
     - name: Create Pull Request
-      if: steps.update.outputs.create_pull_request == 'true'
+      if: {{ steps.update.outputs.create_pull_request == 'true' }}
       uses: cloudposse/actions/github/create-pull-request@0.22.0
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -9,8 +9,6 @@ jobs:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
     - uses: mszostok/codeowners-validator@v0.5.0
-      if: github.event.pull_request.head.repo.full_name == github.repository
-      name: "Full check of CODEOWNERS"
       with:
         # For now, remove "files" check to allow CODEOWNERS to specify non-existent
         # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
@@ -18,8 +16,3 @@ jobs:
         checks: "syntax,owners,duppatterns"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
-    - uses: mszostok/codeowners-validator@v0.5.0
-      if: github.event.pull_request.head.repo.full_name != github.repository
-      name: "Syntax check of CODEOWNERS"
-      with:
-        checks: "syntax,duppatterns"

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/context.tf
+++ b/context.tf
@@ -18,10 +18,9 @@
 # will be null, and `module.this.delimiter` will be `-` (hyphen).
 #
 
-
 module "this" {
   source  = "cloudposse/label/null"
-  version = "0.22.0" // requires Terraform >= 0.12.26
+  version = "0.22.1" // requires Terraform >= 0.12.26
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -18,10 +18,9 @@
 # will be null, and `module.this.delimiter` will be `-` (hyphen).
 #
 
-
 module "this" {
   source  = "cloudposse/label/null"
-  version = "0.22.0" // requires Terraform >= 0.12.26
+  version = "0.22.1" // requires Terraform >= 0.12.26
 
   enabled             = var.enabled
   namespace           = var.namespace


### PR DESCRIPTION
## what
- Upgrade to support Terraform 0.14 and bring up to current Cloud Posse standard

## why
- Support Terraform 0.14
